### PR TITLE
401오류에 따른 token 갱신

### DIFF
--- a/RemeberTest/ViewController.swift
+++ b/RemeberTest/ViewController.swift
@@ -27,7 +27,7 @@ class ViewController: UIViewController {
     func viewDidLoad() {
         super.viewDidLoad()
 
-        GitHubAPI.shared.token = "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"
+        GitHubAPI.shared.token = "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"
 
         loadHead()
         loadBody()


### PR DESCRIPTION
API 사용시 401오류가 발생되어 토큰 갱신처리